### PR TITLE
Fixed lighting bug with Vintagium

### DIFF
--- a/src/main/java/dev/redstudio/alfheim/Alfheim.java
+++ b/src/main/java/dev/redstudio/alfheim/Alfheim.java
@@ -22,4 +22,5 @@ public final class Alfheim {
     public static final byte FLAG_COUNT = 32; // 2 light types * 4 directions * 2 halves * (inwards + outwards)
 
     public static final boolean IS_NOTHIRIUM_LOADED = Loader.isModLoaded("nothirium");
+    public static final boolean IS_VINTAGIUM_LOADED = Loader.isModLoaded("vintagium");
 }

--- a/src/main/java/dev/redstudio/alfheim/mixin/client/RenderGlobalMixin.java
+++ b/src/main/java/dev/redstudio/alfheim/mixin/client/RenderGlobalMixin.java
@@ -16,7 +16,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import static dev.redstudio.alfheim.Alfheim.IS_NOTHIRIUM_LOADED;
-import static dev.redstudio.alfheim.ProjectConstants.LOGGER;
+import static dev.redstudio.alfheim.Alfheim.IS_VINTAGIUM_LOADED;
 
 /**
  * @author Luna Lage (Desoroxxx)
@@ -53,7 +53,7 @@ public abstract class RenderGlobalMixin implements ILightUpdatesProcessor {
      */
     @Override
     public void alfheim$processLightUpdates() {
-        if (setLightUpdates.isEmpty() || (!IS_NOTHIRIUM_LOADED && renderDispatcher.hasNoFreeRenderBuilders()))
+        if (setLightUpdates.isEmpty() || (!IS_NOTHIRIUM_LOADED && !IS_VINTAGIUM_LOADED && renderDispatcher.hasNoFreeRenderBuilders()))
             return;
 
         final Iterator<BlockPos> iterator = setLightUpdates.iterator();


### PR DESCRIPTION
Probably related to #40

## 📝 Description

We can't rely on vanilla's ChunkRenderDispatcher while using Vintagium. Change is similar to commit ->  https://github.com/Asek3/sodium-1.12/commit/d947ba573dfd8ab91afa1fe50455ab41326563da


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added compatibility check for the "vintagium" mod to enhance material loading conditions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->